### PR TITLE
Fix compilation for mirage-crypto > 1.0.0

### DIFF
--- a/hyper.opam
+++ b/hyper.opam
@@ -17,8 +17,8 @@ depends: [
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}
   "lwt_ppx"
-  "mirage-crypto-rng"
-  "mirage-crypto-rng-lwt"
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "mirage-crypto-rng-lwt" {>= "1.0.0"}
   "ocaml" {>= "4.08.0"}
   "uri"
 

--- a/src/http/websocket.ml
+++ b/src/http/websocket.ml
@@ -110,7 +110,7 @@ let ws socket request =
 
   let%lwt client =
     Websocketaf_lwt_unix.Client.connect
-      ~nonce:(Cstruct.to_string (Mirage_crypto_rng.generate 16))
+      ~nonce:(Mirage_crypto_rng.generate 16)
       ~host
       ~port
       ~resource:(Uri.path_and_query target)


### PR DESCRIPTION
`mirage-crypto` no longer uses `Cstruct`, so this commit is a quick and dirty way to get `hyper` to compile with the latest `dream` dependencies